### PR TITLE
feat: add Cloud.ru Evo DNS support

### DIFF
--- a/providers/dns/cloudru/cloudru_test.go
+++ b/providers/dns/cloudru/cloudru_test.go
@@ -11,7 +11,7 @@ import (
 const envDomain = envNamespace + "DOMAIN"
 
 var envTest = tester.NewEnvTest(
-	EnvServiceInstanceID,
+	EnvProjectID,
 	EnvKeyID,
 	EnvSecret).
 	WithDomain(envDomain)
@@ -25,9 +25,9 @@ func TestNewDNSProvider(t *testing.T) {
 		{
 			desc: "success",
 			envVars: map[string]string{
-				EnvServiceInstanceID: "123",
-				EnvKeyID:             "user",
-				EnvSecret:            "secret",
+				EnvProjectID: "123",
+				EnvKeyID:     "user",
+				EnvSecret:    "secret",
 			},
 		},
 		{
@@ -38,27 +38,27 @@ func TestNewDNSProvider(t *testing.T) {
 		{
 			desc: "missing service instance ID",
 			envVars: map[string]string{
-				EnvServiceInstanceID: "",
-				EnvKeyID:             "user",
-				EnvSecret:            "secret",
+				EnvProjectID: "",
+				EnvKeyID:     "user",
+				EnvSecret:    "secret",
 			},
 			expected: "cloudru: some credentials information are missing: CLOUDRU_SERVICE_INSTANCE_ID",
 		},
 		{
 			desc: "missing key ID",
 			envVars: map[string]string{
-				EnvServiceInstanceID: "123",
-				EnvKeyID:             "",
-				EnvSecret:            "secret",
+				EnvProjectID: "123",
+				EnvKeyID:     "",
+				EnvSecret:    "secret",
 			},
 			expected: "cloudru: some credentials information are missing: CLOUDRU_KEY_ID",
 		},
 		{
 			desc: "missing secret",
 			envVars: map[string]string{
-				EnvServiceInstanceID: "123",
-				EnvKeyID:             "user",
-				EnvSecret:            "",
+				EnvProjectID: "123",
+				EnvKeyID:     "user",
+				EnvSecret:    "",
 			},
 			expected: "cloudru: some credentials information are missing: CLOUDRU_SECRET",
 		},
@@ -129,7 +129,7 @@ func TestNewDNSProviderConfig(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			config := NewDefaultConfig()
-			config.ServiceInstanceID = test.serviceInstanceID
+			config.ProjectID = test.serviceInstanceID
 			config.KeyID = test.keyID
 			config.Secret = test.secret
 

--- a/providers/dns/cloudru/internal/client_test.go
+++ b/providers/dns/cloudru/internal/client_test.go
@@ -65,13 +65,15 @@ func TestClient_GetZones(t *testing.T) {
 
 	expected := []Zone{
 		{
-			ID:        "59556fcd-95ff-451f-b49b-9732f21f944a",
-			ParentID:  "2d7b6194-2b83-4f71-86fd-a1e727e347b2",
-			Name:      "example.com",
-			Valid:     true,
-			Delegated: true,
-			CreatedAt: time.Date(2023, 7, 23, 8, 12, 41, 0, time.UTC),
-			UpdatedAt: time.Date(2023, 7, 24, 5, 50, 28, 0, time.UTC),
+			Meta: Meta{
+				ID:        "59556fcd-95ff-451f-b49b-9732f21f944a",
+				CreateAt:  time.Date(2023, 7, 23, 8, 12, 41, 0, time.UTC),
+				UpdatedAt: time.Date(2023, 7, 24, 5, 50, 28, 0, time.UTC),
+			},
+			ProjectID:   "2d7b6194-2b83-4f71-86fd-a1e727e347b2",
+			Name:        "example.com",
+			ActiveState: true,
+			State:       "STATE_OK",
 		},
 	}
 	assert.Equal(t, expected, zones)
@@ -91,21 +93,19 @@ func TestClient_GetRecords(t *testing.T) {
 			Name:   "example.com.",
 			Type:   "SOA",
 			Values: []string{
-				"cdns-ns01.sbercloud.ru. mail.sbercloud.ru 1 120 3600 604800 3600",
+				"evo-cns01.cloud.ru. mail.sbercloud.ru 1 120 3600 604800 3600",
 			},
-			TTL:     "3600",
-			Enables: true,
+			TTL: 3600,
 		},
 		{
 			ZoneID: "59556fcd-95ff-451f-b49b-9732f21f944a",
 			Name:   "example.com.",
 			Type:   "NS",
 			Values: []string{
-				"cdns-ns01.sbercloud.ru.",
-				"cdns-ns02.sbercloud.ru.",
+				"evo-cns01.cloud.ru.",
+				"evo-cns02.cloud.ru.",
 			},
-			TTL:     "3600",
-			Enables: true,
+			TTL: 3600,
 		},
 		{
 			ZoneID: "59556fcd-95ff-451f-b49b-9732f21f944a",
@@ -114,8 +114,7 @@ func TestClient_GetRecords(t *testing.T) {
 			Values: []string{
 				"8.8.8.8",
 			},
-			TTL:     "3600",
-			Enables: true,
+			TTL: 3600,
 		},
 	}
 	assert.Equal(t, expected, records)
@@ -126,14 +125,15 @@ func TestClient_CreateRecord(t *testing.T) {
 
 	ctx := mockContext()
 
-	recordReq := Record{
+	recordReq := CreateRecordRequest{
 		Name:   "www.example.com.",
 		Type:   "TXT",
 		Values: []string{"text"},
-		TTL:    "3600",
+		TTL:    3600,
+		ZoneID: "59556fcd-95ff-451f-b49b-9732f21f944a",
 	}
 
-	record, err := client.CreateRecord(ctx, "zzz", recordReq)
+	record, err := client.CreateRecord(ctx, recordReq)
 	require.NoError(t, err)
 
 	expected := &Record{
@@ -143,8 +143,7 @@ func TestClient_CreateRecord(t *testing.T) {
 		Values: []string{
 			"txt",
 		},
-		TTL:     "3600",
-		Enables: true,
+		TTL: 3600,
 	}
 	assert.Equal(t, expected, record)
 }

--- a/providers/dns/cloudru/internal/types.go
+++ b/providers/dns/cloudru/internal/types.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const TxtRecordType = "PUBLIC_RECORD_MANAGED_TYPE_TXT"
+
 type Token struct {
 	// The bearer token for use in API requests
 	AccessToken string `json:"access_token"`
@@ -27,27 +29,59 @@ func (a authResponseError) Error() string {
 	return fmt.Sprintf("%s: %s", a.ErrorMsg, a.ErrorDescription)
 }
 
-type APIResponse[T any] struct {
-	Items []T `json:"items"`
+type ZonesAPIResponse struct {
+	Zones  []Zone `json:"zones"`
+	Page   int    `json:"page"`
+	Offset int    `json:"offset"`
+	Total  int    `json:"total"`
 }
 
 type Zone struct {
-	ID             string    `json:"id,omitempty"`
-	ParentID       string    `json:"parent_id,omitempty"`
-	Name           string    `json:"name,omitempty"`
-	Valid          bool      `json:"valid,omitempty"`
-	ValidationText string    `json:"validationText,omitempty"`
-	Delegated      bool      `json:"delegated,omitempty"`
-	LastCheck      time.Time `json:"lastCheck,omitempty"`
-	CreatedAt      time.Time `json:"created_at,omitempty"`
-	UpdatedAt      time.Time `json:"updated_at,omitempty"`
+	Meta         Meta          `json:"meta,omitempty"`
+	ProjectID    string        `json:"projectId,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Domain       string        `json:"domain,omitempty"`
+	Role         string        `json:"role,omitempty"`
+	ReadOnly     bool          `json:"readOnly,omitempty"`
+	ActiveState  bool          `json:"activeState,omitempty"`
+	State        string        `json:"state,omitempty"`
+	CountRecords string        `json:"countRecords,omitempty"`
+	CountValues  string        `json:"countValues,omitempty"`
+	Description  string        `json:"description,omitempty"`
+	Tags         []interface{} `json:"tags,omitempty"`
+}
+
+type RecordsAPIResponse struct {
+	Records []Record `json:"records"`
+	Page    int      `json:"page"`
+	Offset  int      `json:"offset"`
+	Total   int      `json:"total"`
 }
 
 type Record struct {
-	ZoneID  string   `json:"zone_id,omitempty"`
-	Name    string   `json:"name,omitempty"`
-	Type    string   `json:"type,omitempty"`
-	Values  []string `json:"values,omitempty"`
-	TTL     string   `json:"ttl,omitempty"`
-	Enables bool     `json:"enables,omitempty"`
+	Meta        Meta          `json:"meta,omitempty"`
+	ZoneID      string        `json:"zoneId,omitempty"`
+	Name        string        `json:"name,omitempty"`
+	Type        string        `json:"type,omitempty"`
+	Values      []string      `json:"values,omitempty"`
+	TTL         int           `json:"ttl,omitempty"`
+	ReadOnly    bool          `json:"readOnly,omitempty"`
+	Description string        `json:"description,omitempty"`
+	Tags        []interface{} `json:"tags,omitempty"`
+	State       string        `json:"state,omitempty"`
+}
+
+type CreateRecordRequest struct {
+	Type   string   `json:"type"`
+	Name   string   `json:"name"`
+	TTL    int      `json:"ttl"`
+	Values []string `json:"values"`
+	ZoneID string   `json:"zoneId"`
+}
+
+type Meta struct {
+	ID        string    `json:"id,omitempty"`
+	TaskID    string    `json:"taskId,omitempty"`
+	CreateAt  time.Time `json:"createAt,omitempty"`
+	UpdatedAt time.Time `json:"updatedAtv"`
 }


### PR DESCRIPTION
replace cloud.ru Cloud DNS (v1) with Cloud.ru Evo DNS (v2) because the first one is deprecated.

TODO: fix autotests for new version.